### PR TITLE
Fix for dots in sample names

### DIFF
--- a/agrvate
+++ b/agrvate
@@ -5,7 +5,7 @@
 
 
 
-version="1.0"
+version="1.0.1"
 USAGE=$(echo -e "\n\
 AgrVATE: Agr Variant Assessment & Typing Engine \n\n\
 VERSION: agrvate v$version \n\n\
@@ -135,7 +135,7 @@ if [[ -f $fasta_path ]] #Check if input is a file
 		 then	
 			if [[ $(grep -v ">" $fasta_path | grep -q -i "[^ATCGNWSMKRY]"; echo $?) -eq 1 ]] #check if seqence has characters other than ATGCN
 			 then
-				fna_name=$(echo "$bname" | cut -f1 -d".")
+				fna_name="${bname%.*}"
 				input_check="pass"
 			else
 				1>&2 echo -e "Seqence has non-standard nucleic acid characters\n$USAGE" 


### PR DESCRIPTION
I used parameter expansion, seen here: https://unix.stackexchange.com/a/217632

Here's what the outputs look like with the change.
```
$agrvate -i ~/test/S.201202.00877.fna -m
Processing /local/home/rpetit/test/S.201202.00877.fna ...
/local/home/rpetit/miniconda3/envs/staph-typer2/bin/agrvate_databases/ is valid
agr typing successful, gp3
Mummer successful
Unable to find agr operon, check S.201202.00877-results/S.201202.00877-mummer-log.txt

$ agrvate -i ~/test/SRX2478920.fna -m -f
Processing /local/home/rpetit/test/SRX2478920.fna ...
/local/home/rpetit/miniconda3/envs/staph-typer2/bin/agrvate_databases/ is valid
agr typing successful, gp1
Mummer successful
Extracting agr operon from mummer output
agr operon extraction successful
Snippy successful
No frameshifts found

$ find
.
./SRX2478920-results
./SRX2478920-results/SRX2478920-agr_operon.fna
./SRX2478920-results/SRX2478920-blastn_log.txt
./SRX2478920-results/SRX2478920-agr_gp.tab
./SRX2478920-results/SRX2478920-mummer
./SRX2478920-results/SRX2478920-mummer/out.snps
./SRX2478920-results/SRX2478920-mummer/out.mdelta
./SRX2478920-results/SRX2478920-mummer/out.1coords
./SRX2478920-results/SRX2478920-mummer/out.unqry
./SRX2478920-results/SRX2478920-mummer/out.mcoords
./SRX2478920-results/SRX2478920-mummer/out.report
./SRX2478920-results/SRX2478920-mummer/out.1delta
./SRX2478920-results/SRX2478920-mummer/out.delta
./SRX2478920-results/SRX2478920-mummer/out.qdiff
./SRX2478920-results/SRX2478920-mummer/out.rdiff
./SRX2478920-results/SRX2478920-snippy
./SRX2478920-results/SRX2478920-snippy/snps.consensus.subs.fa
./SRX2478920-results/SRX2478920-snippy/snps.consensus.fa
./SRX2478920-results/SRX2478920-snippy/snps.log
./SRX2478920-results/SRX2478920-snippy/ref.fa.fai
./SRX2478920-results/SRX2478920-snippy/snps.bam
./SRX2478920-results/SRX2478920-snippy/snps.aligned.fa
./SRX2478920-results/SRX2478920-snippy/snps.gff
./SRX2478920-results/SRX2478920-snippy/snps.vcf
./SRX2478920-results/SRX2478920-snippy/snps.raw.vcf
./SRX2478920-results/SRX2478920-snippy/snps.vcf.gz.csi
./SRX2478920-results/SRX2478920-snippy/ref.fa
./SRX2478920-results/SRX2478920-snippy/snps.tab
./SRX2478920-results/SRX2478920-snippy/snps.subs.vcf
./SRX2478920-results/SRX2478920-snippy/reference
./SRX2478920-results/SRX2478920-snippy/reference/ref.txt
./SRX2478920-results/SRX2478920-snippy/reference/ref.fa.fai
./SRX2478920-results/SRX2478920-snippy/reference/snpeff.config
./SRX2478920-results/SRX2478920-snippy/reference/ref.fa.ann
./SRX2478920-results/SRX2478920-snippy/reference/ref.fa.pac
./SRX2478920-results/SRX2478920-snippy/reference/ref.fa.bwt
./SRX2478920-results/SRX2478920-snippy/reference/ref.gff
./SRX2478920-results/SRX2478920-snippy/reference/ref.fa.amb
./SRX2478920-results/SRX2478920-snippy/reference/ref.fa.sa
./SRX2478920-results/SRX2478920-snippy/reference/ref
./SRX2478920-results/SRX2478920-snippy/reference/ref/genes.gff.gz
./SRX2478920-results/SRX2478920-snippy/reference/ref/snpEffectPredictor.bin
./SRX2478920-results/SRX2478920-snippy/reference/ref.fa
./SRX2478920-results/SRX2478920-snippy/reference/genomes
./SRX2478920-results/SRX2478920-snippy/reference/genomes/ref.fa
./SRX2478920-results/SRX2478920-snippy/snps.filt.vcf
./SRX2478920-results/SRX2478920-snippy/snps.html
./SRX2478920-results/SRX2478920-snippy/snps.vcf.gz
./SRX2478920-results/SRX2478920-snippy/snps.bed
./SRX2478920-results/SRX2478920-snippy/snps.csv
./SRX2478920-results/SRX2478920-snippy/snps.bam.bai
./SRX2478920-results/SRX2478920-snippy/snps.txt
./SRX2478920-results/SRX2478920-snippy-log.txt
./SRX2478920-results/SRX2478920-mummer-log.txt
./SRX2478920-results/SRX2478920-summary.tab
./SRX2478920-results/SRX2478920-agr_operon_frameshifts.tab
./S.201202.00877-results
./S.201202.00877-results/S.201202.00877-mummer-log.txt
./S.201202.00877-results/S.201202.00877-summary.tab
./S.201202.00877-results/S.201202.00877-agr_gp.tab
./S.201202.00877-results/S.201202.00877-blastn_log.txt
./S.201202.00877-results/S.201202.00877-mummer
./S.201202.00877-results/S.201202.00877-mummer/out.snps
./S.201202.00877-results/S.201202.00877-mummer/out.mdelta
./S.201202.00877-results/S.201202.00877-mummer/out.1coords
./S.201202.00877-results/S.201202.00877-mummer/out.unqry
./S.201202.00877-results/S.201202.00877-mummer/out.mcoords
./S.201202.00877-results/S.201202.00877-mummer/out.report
./S.201202.00877-results/S.201202.00877-mummer/out.1delta
./S.201202.00877-results/S.201202.00877-mummer/out.delta
./S.201202.00877-results/S.201202.00877-mummer/out.qdiff
./S.201202.00877-results/S.201202.00877-mummer/out.rdiff
./S.201202.00877.fna-error-report.tab
./SRX2478920.fna-error-report.tab
```